### PR TITLE
Add Windows path manipulation functions

### DIFF
--- a/src/button-lua.cc
+++ b/src/button-lua.cc
@@ -99,6 +99,12 @@ int init(lua_State* L) {
     luaL_requiref(L, "path", luaopen_path, 1);
     lua_pop(L, 1);
 
+    luaL_requiref(L, "winpath", luaopen_winpath, 1);
+    lua_pop(L, 1);
+
+    luaL_requiref(L, "posixpath", luaopen_posixpath, 1);
+    lua_pop(L, 1);
+
     lua_pushcfunction(L, lua_glob);
     lua_setglobal(L, "glob");
 

--- a/src/lua_path.cc
+++ b/src/lua_path.cc
@@ -13,6 +13,17 @@
 #include "lua.hpp"
 
 template<class Path>
+static int path_splitroot(lua_State* L) {
+    size_t len;
+    const char* path = luaL_checklstring(L, 1, &len);
+
+    const Split<Path> s = Path(path, len).splitRoot();
+    lua_pushlstring(L, s.head.path, s.head.length);
+    lua_pushlstring(L, s.tail.path, s.tail.length);
+    return 2;
+}
+
+template<class Path>
 static int path_isabs(lua_State* L) {
     size_t len;
     const char* path = luaL_checklstring(L, 1, &len);
@@ -149,7 +160,8 @@ static int path_norm(lua_State* L) {
     return 1;
 }
 
-static const luaL_Reg pathlib[] = {
+static const luaL_Reg pathlib_posix[] = {
+    {"splitroot", path_splitroot<PosixPath>},
     {"isabs", path_isabs<PosixPath>},
     {"join", path_join<PosixPath>},
     {"split", path_split<PosixPath>},
@@ -163,7 +175,36 @@ static const luaL_Reg pathlib[] = {
     {NULL, NULL}
 };
 
+static const luaL_Reg pathlib_win[] = {
+    {"splitroot", path_splitroot<WinPath>},
+    {"isabs", path_isabs<WinPath>},
+    {"join", path_join<WinPath>},
+    {"split", path_split<WinPath>},
+    {"basename", path_basename<WinPath>},
+    {"dirname", path_dirname<WinPath>},
+    {"splitext", path_splitext<WinPath>},
+    {"getext", path_getext<WinPath>},
+    {"setext", path_setext<WinPath>},
+    {"components", path_components<WinPath>},
+    {"norm", path_norm<WinPath>},
+    {NULL, NULL}
+};
+
 int luaopen_path(lua_State* L) {
-    luaL_newlib(L, pathlib);
+#ifdef _WIN32
+    luaL_newlib(L, pathlib_win);
+#else
+    luaL_newlib(L, pathlib_posix);
+#endif
+    return 1;
+}
+
+int luaopen_posixpath(lua_State* L) {
+    luaL_newlib(L, pathlib_posix);
+    return 1;
+}
+
+int luaopen_winpath(lua_State* L) {
+    luaL_newlib(L, pathlib_win);
     return 1;
 }

--- a/src/lua_path.h
+++ b/src/lua_path.h
@@ -14,3 +14,5 @@ struct lua_State;
  * Pushes the path library onto the stack so that it can be registered.
  */
 int luaopen_path(lua_State* L);
+int luaopen_posixpath(lua_State* L);
+int luaopen_winpath(lua_State* L);

--- a/src/path.h
+++ b/src/path.h
@@ -9,5 +9,10 @@
 #pragma once
 
 #include "path/posix.h"
+#include "path/windows.h"
 
+#ifdef _WIN32
+using Path = WinPath;
+#else
 using Path = PosixPath;
+#endif

--- a/src/path/posix.cc
+++ b/src/path/posix.cc
@@ -14,17 +14,9 @@ int PosixPath::cmp(char a, char b) {
     if (isSep(a) && isSep(b))
         return 0;
 
-    //return (int)tolower(a) - (int)tolower(b);
     return (int)a - (int)b;
 }
 
-PosixPath PosixPath::root() const {
-    if (length == 1 && isSep(path[0]))
-        return PosixPath(path, 1);
-
-    return PosixPath(nullptr, 0);
-}
-
-bool PosixPath::isabs() const {
-    return length > 0 && isSep(path[0]);
+size_t PosixPath::rootLength() const {
+    return length >= 1 && isSep(path[0]);
 }

--- a/src/path/windows.cc
+++ b/src/path/windows.cc
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Jason White
+ *
+ * MIT License
+ *
+ * Description:
+ * File path manipulation for Windows.
+ *
+ * Reference:
+ * https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx
+ */
+
+#include <cctype>
+#include <cstring>
+#include <algorithm>
+
+#include "path/windows.h"
+#include "lua.hpp"
+
+int WinPath::cmp(char a, char b) {
+    if (isSep(a) && isSep(b))
+        return 0;
+
+    return (int)tolower(a) - (int)tolower(b);
+}
+
+/**
+ * Be sure to compare the simplicity of this function with that of
+ * PosixPath::rootLength(). Path manipulation on Windows is goddamn insane.
+ */
+size_t WinPath::rootLength() const {
+    if (length >= 4 && strncmp(path, "\\\\?\\", 4) == 0) {
+        // Path starts with "\\?\". This is used to allow paths longer than 260
+        // characters (but only for UTF-16 Windows API functions). Such elegant
+        // design.
+
+        // Either a drive or a UNC path can follow this. We need to include
+        // those in the absolute part as well.
+        if (length >= 7 && path[5] == ':' && isSep(path[6])) {
+            // Path is of the form "\\?\C:\". 7 characters long.
+            return 7;
+        }
+        else if (length >= 8 && strncmp(path+4, "UNC\\", 4) == 0) {
+            // Path is of the form "\\?\UNC\server\share".
+            size_t i = 8;
+
+            // Skip past the server name.
+            while (i < length && !isSep(path[i])) ++i;
+
+            if (i > 8 && i < length) {
+                ++i; // Skip past the path separator
+
+                // Skip past the share name
+                while (i < length && !isSep(path[i])) ++i;
+
+                return i;
+            }
+        }
+
+        // At the very least, include "\\?\".
+        return 4;
+    }
+    else if (length >= 4 && strncmp(path, "\\\\.\\", 4) == 0) {
+        // A device name follows. We need to include that in the absolute part
+        // as well.
+        size_t i = 4;
+
+        // Skip past the device name.
+        while (i < length && !isSep(path[i])) ++i;
+
+        return i;
+    }
+    else if (length >= 4 && isSep(path[0]) && isSep(path[1])) {
+        // Path is a UNC path (e.g., "\\server\share").
+        size_t i = 2;
+
+        // Skip past the server name
+        while (i < length && !isSep(path[i])) ++i;
+
+        if (i > 2 && i < length) {
+            ++i; // Skip past the path separator
+
+            // Skip past the share name
+            while (i < length && !isSep(path[i])) ++i;
+
+            return i;
+        }
+    }
+    else if (length >= 3 && path[1] == ':' && isSep(path[2])) {
+        // Path starts with "X:\" or "X:/".
+        return 3;
+    }
+    else if (length >= 1 && isSep(path[0])) {
+        // Path starts with a single path separator (and nothing more).
+        if (length >= 2) {
+            if (!isSep(path[1]))
+                return 1;
+        }
+        else {
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/src/path/windows.h
+++ b/src/path/windows.h
@@ -15,17 +15,17 @@
 
 #include "path/base.h"
 
-class PosixPath : public BasePath<PosixPath> {
+class WinPath : public BasePath<WinPath> {
 public:
-    using BasePath<PosixPath>::BasePath;
+    using BasePath<WinPath>::BasePath;
 
-    static const char defaultSep = '/';
-    static const bool caseSensitive = true;
+    static const char defaultSep = '\\';
+    static const bool caseSensitive = false;
 
     static int cmp(char a, char b);
 
     static inline bool isSep(char c) {
-        return c == '/';
+        return c == '/' || c == '\\';
     }
 
     size_t rootLength() const;

--- a/tests/std.sh
+++ b/tests/std.sh
@@ -6,6 +6,7 @@
 # Tests additions to the standard Lua library.
 
 runtest std/globals.sh
-runtest std/path.sh
+runtest std/posixpath.sh
+runtest std/winpath.sh
 runtest std/string.sh
 runtest std/glob.sh

--- a/tests/std/posixpath.lua
+++ b/tests/std/posixpath.lua
@@ -1,0 +1,194 @@
+--[[
+Copyright 2016 Jason White. MIT license.
+
+Description:
+Tests the path manipulation functions for Posix.
+]]
+
+local path = posixpath;
+
+--[[
+    Get the root part of the path.
+]]
+assert(path.splitroot("/") == "/")
+assert(path.splitroot("/foo") == "/")
+assert(path.splitroot("foo") == "")
+
+--[[
+    path.isabs
+]]
+assert(path.isabs("/"))
+assert(path.isabs("/foo/bar"))
+assert(not path.isabs("foo"))
+assert(not path.isabs(""))
+
+
+--[[
+    path.join
+]]
+assert(path.join() == "")
+assert(path.join("") == "")
+assert(path.join("", "") == "")
+assert(path.join("foo") == "foo")
+assert(path.join("foo", "bar") == "foo/bar")
+assert(path.join("foo", "/bar") == "/bar")
+assert(path.join("foo/", "bar") == "foo/bar")
+assert(path.join("foo/", nil, "bar") == "foo/bar")
+assert(path.join("foo//", "bar") == "foo//bar")
+assert(path.join("/", "foo") == "/foo")
+assert(path.join("foo", "") == "foo/")
+assert(path.join("foo", nil) == "foo")
+assert(path.join("", "foo") == "foo")
+assert(path.join(nil, "foo") == "foo")
+
+
+--[[
+    path.split
+]]
+
+local split_tests = {
+    {"", "", "", ""},
+    {"/", "/", "", "/"},
+    {"foo", "", "foo", "foo"},
+    {"/foo", "/", "foo", "/foo"},
+    {"foo/bar", "foo", "bar", "foo/bar"},
+    {"foo/", "foo", "", "foo/"},
+    {"/foo////bar", "/foo", "bar", "/foo/bar"},
+    {"////foo////bar", "////foo", "bar", "////foo/bar"},
+}
+
+local split_error = 'In path.split("%s"): expected "%s", got "%s"'
+
+for k,v in ipairs(split_tests) do
+    local head, tail = path.split(v[1])
+    assert(head == v[2], string.format(split_error, v[1], v[2], head))
+    assert(tail == v[3], string.format(split_error, v[1], v[3], tail))
+    assert(path.join(head, tail) == v[4],
+        string.format(split_error, v[1], v[4], path.join(head, tail)))
+end
+
+
+--[[
+    path.basename
+]]
+assert(path.basename("") == "")
+assert(path.basename("/") == "")
+assert(path.basename("/foo") == "foo")
+assert(path.basename("/foo/bar") == "bar")
+assert(path.basename("////foo////bar") == "bar")
+assert(path.basename("/foo/bar/") == "")
+
+--[[
+    path.dirname
+]]
+assert(path.dirname("") == "")
+assert(path.dirname("/") == "/")
+assert(path.dirname("/foo") == "/")
+assert(path.dirname("/foo/bar") == "/foo")
+assert(path.dirname("/foo/bar/") == "/foo/bar")
+
+
+--[[
+    path.splitext
+]]
+
+local splitext_tests = {
+    {"", "", ""},
+    {"/", "/", ""},
+    {"foo", "foo", ""},
+    {".foo", ".foo", ""},
+    {"foo.bar", "foo", ".bar"},
+    {"foo/bar.baz", "foo/bar", ".baz"},
+    {"foo/.bar.baz", "foo/.bar", ".baz"},
+    {"foo/....bar.baz", "foo/....bar", ".baz"},
+    {"/....bar", "/....bar", ""},
+}
+
+local split_error = 'In path.splitext("%s"): expected "%s", got "%s"'
+
+for k,v in ipairs(splitext_tests) do
+    local root, ext = path.splitext(v[1])
+    assert(root == v[2], string.format(split_error, v[1], root, v[2]))
+    assert(ext  == v[3], string.format(split_error, v[1], ext, v[3]))
+    assert(root .. ext == v[1])
+end
+
+--[[
+    path.getext
+]]
+
+assert(path.getext("") == "")
+assert(path.getext("/") == "")
+assert(path.getext("/foo") == "")
+assert(path.getext("/foo.") == ".")
+assert(path.getext("/foo.bar") == ".bar")
+assert(path.getext("/.foo.bar") == ".bar")
+
+--[[
+    path.getext
+]]
+
+assert(path.setext("", ".c") == ".c")
+assert(path.setext("/", ".c") == "/.c")
+assert(path.setext("foo", ".c") == "foo.c")
+assert(path.setext("foo.", ".c") == "foo.c")
+assert(path.setext("foo.bar", ".c") == "foo.c")
+assert(path.setext(".foo.bar", ".c") == ".foo.c")
+assert(path.setext(".foo", ".c") == ".foo.c")
+
+--[[
+    path.components
+]]
+
+local components_tests = {
+    {"", {}, ""},
+    {"foo", {"foo"}, "foo"},
+    {"foo/", {"foo"}, "foo"},
+    {"foo/bar", {"foo", "bar"}, "foo/bar"},
+    {"foo/bar/", {"foo", "bar"}, "foo/bar"},
+    {"/foo/bar/", {"/", "foo", "bar"}, "/foo/bar"},
+    {"foo///bar", {"foo", "bar"}, "foo/bar"},
+    {"/foo/bar", {"/", "foo", "bar"}, "/foo/bar"},
+    {"../foo/bar/baz", {"..", "foo", "bar", "baz"}, "../foo/bar/baz"},
+}
+
+local components_error = 'In path.components("%s"): expected %s, got %s'
+
+for _,v in ipairs(components_tests) do
+    local components = {path.components(v[1])}
+
+    local got = table.show(components, "")
+    local expected = table.show(v[2], "")
+
+    assert(#components == #v[2],
+        string.format(components_error, v[1], expected, got))
+
+    for i,c in ipairs(components) do
+        assert(c == v[2][i],
+            string.format(components_error, v[1], c, v[2][i]))
+    end
+
+    local joined = path.join(table.unpack(components))
+    assert(joined == v[3],
+        string.format('In path.components("%s"): got joined path "%s", expected "%s"',
+        v[1], joined, v[3]))
+end
+
+--[[
+    path.norm
+]]
+assert(path.norm("") == ".")
+assert(path.norm(".") == ".")
+assert(path.norm("foo") == "foo")
+assert(path.norm("./foo") == "foo")
+assert(path.norm("/foo") == "/foo")
+assert(path.norm("foo//bar") == "foo/bar")
+assert(path.norm("foo/./bar") == "foo/bar")
+assert(path.norm("foo/../bar") == "bar")
+assert(path.norm("foo/../bar/..") == ".")
+assert(path.norm("../foo/../bar") == "../bar")
+assert(path.norm("/../foo/../bar") == "/bar")
+assert(path.norm("/../../.././bar/") == "/bar")
+assert(path.norm("../foo/../bar/") == "../bar")
+assert(path.norm("../foo/../bar///") == "../bar")
+assert(path.norm("../path/./to//a/../b/c/../../test.txt/") == "../path/to/test.txt")

--- a/tests/std/posixpath.sh
+++ b/tests/std/posixpath.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 # Copyright (c) 2016 Jason White
 # MIT License
-button-lua path.lua -o /dev/null
+button-lua posixpath.lua -o /dev/null

--- a/tests/std/winpath.sh
+++ b/tests/std/winpath.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+# Copyright (c) 2016 Jason White
+# MIT License
+button-lua winpath.lua -o /dev/null


### PR DESCRIPTION
This makes both Windows and Posix path modules available as `winpath` and `posixpath`, respectively. The appropriate implementation for the `path` module is chosen at compile time. This makes it easy to test both Posix path manipulation and Windows path manipulation on any platform. Much of the path manipulation code is shared between the two, making the Posix- and Windows-specific bits very small.

Full Windows support is still not done.